### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency: ${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v2
         with:
           version: 7.6.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '16'
           cache: 'pnpm'

--- a/.github/workflows/test-on-pull-request.yml
+++ b/.github/workflows/test-on-pull-request.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-22.04
     concurrency: ${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v2
         with:
           version: 7.6.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: '16'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v3` → `actions/checkout@v6`
- `actions/setup-node@v3` → `actions/setup-node@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that upgrades GitHub Actions dependencies; main impact is potential CI behavior differences from newer `actions/checkout`/`actions/setup-node` versions.
> 
> **Overview**
> Updates CI workflows to use Node.js 24-compatible GitHub Actions by bumping `actions/checkout` and `actions/setup-node` from `@v3` to `@v6` in both `release-on-merge.yml` and `test-on-pull-request.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d00ff8c0696779c260a402ce13f03c60afcb800e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->